### PR TITLE
added constraint to flake8-isort because of compatibility with isort

### DIFF
--- a/{{cookiecutter.module_name}}/requirements.dev.txt
+++ b/{{cookiecutter.module_name}}/requirements.dev.txt
@@ -1,7 +1,7 @@
 pytest-inmanta
 flake8
 flake8-black
-flake8-isort>3
+flake8-isort>3.0.0
 flake8-copyright
 isort
 black


### PR DESCRIPTION
The situation is as follows:
1. `flake8-isort-3.0.0` is not compatible with the latest `isort<5`, even though its `setup.py` says it should be (might be a non-backwards compatible change on `isort`, I haven't checked.
2. I believe there is a bug in pip where it fails to detect that `flake8-3.9.2` is compatible with `flake8-isort-4.0.0`. As a result it installs `flake8-4.0.1` and `flake8-isort-3.0.0`.

The combination of these two points leads to the build failure: (2) leads to the `flake8-isort` version being installed that because of (1) leads to an exception due to incompatibility with `isort`.

What would solve this:
- Resolve the bug in pip: this would make it so this wouldn't occur, because (2) wouldn't happen, and pip would install `flake8-3.9.2` and `flake8-4.0.1`, which doesn't have the issue from (1). It wouldn't make it so it couldn't occur in theory though, because we still allow `flake8-isort<=3.0.0` even though pip would never reach it.
- Constrain `flake8-isort>3.0.0` as the pull request suggests. This forces pip to reconsider rejecting `flake8-3.9.2` (don't ask me how), leading to the expected versions being installed. The backtracking over flake8 versions still occurs but it will disappear if the bug on pip gets fixed
- Constrain `flake8<4`: this would make it so the backtracking does not occur, working around the bug in pip. It would on the other hand be rather limiting and we'd need to update this in the future.

I believe the approach suggested in this pull request is a good solution: it works around the issue for now, but in a nonintrusive way (it disallows `flake8-isort<3` but still allows `flake8-isort~=3.0.1` (which doesn't have the issue).

closes #11


EDIT:
Just now they've responded over at pip/resolvelib that they consider this a wontfix. I'm still trying to move the discussion along. We'll see how it goes but we should consider the possibility that this issue continues to exist in pip.