### PR TITLE
Add type hints to test_basic

### DIFF
--- a/{{cookiecutter.module_name}}/tests/test_basics.py
+++ b/{{cookiecutter.module_name}}/tests/test_basics.py
@@ -1,6 +1,4 @@
-from pytest_inmanta.plugin import Project
-
-{% if cookiecutter.license == "ASL 2.0" -%}
+{%- if cookiecutter.license == "ASL 2.0" -%}
 """
     Copyright {{ cookiecutter.copyright }}
 
@@ -25,7 +23,7 @@ from pytest_inmanta.plugin import Project
     :license: {{ cookiecutter.license }}
 """
 {%- endif %}
-
+from pytest_inmanta.plugin import Project
 
 def test_basics(project: Project) -> None:
     project.compile(

--- a/{{cookiecutter.module_name}}/tests/test_basics.py
+++ b/{{cookiecutter.module_name}}/tests/test_basics.py
@@ -25,6 +25,7 @@
 {%- endif %}
 from pytest_inmanta.plugin import Project
 
+
 def test_basics(project: Project) -> None:
     project.compile(
         """

--- a/{{cookiecutter.module_name}}/tests/test_basics.py
+++ b/{{cookiecutter.module_name}}/tests/test_basics.py
@@ -1,4 +1,6 @@
-{%- if cookiecutter.license == "ASL 2.0" -%}
+from pytest_inmanta.plugin import Project
+
+{% if cookiecutter.license == "ASL 2.0" -%}
 """
     Copyright {{ cookiecutter.copyright }}
 
@@ -25,7 +27,7 @@
 {%- endif %}
 
 
-def test_basics(project):
+def test_basics(project: Project) -> None:
     project.compile(
         """
             import {{cookiecutter.module_name}}


### PR DESCRIPTION
Currently, when generating a module, one example test case is created. This test case uses the project fixture, but nothing shows where this fixture is coming from. This PR will add the type hint as this could help a lot new comers.
closes issue #18