### PR TITLE
updated gitignore to reflect v2 pycache locations

### DIFF
--- a/{{cookiecutter.module_name|slugify}}/.gitignore
+++ b/{{cookiecutter.module_name|slugify}}/.gitignore
@@ -1,5 +1,5 @@
-plugins/__pycache__
-tests/__pycache__
+inmanta_plugins/**/__pycache__
+tests/**/__pycache__
 *.orig
 .vscode
 .pytest_cache


### PR DESCRIPTION
We forgot to update this file when we created the v2 template.