### PR TITLE
[FIX] limit namespace packages to inmanta_plugins

### DIFF
--- a/{{cookiecutter.module_name|slugify}}/setup.cfg
+++ b/{{cookiecutter.module_name|slugify}}/setup.cfg
@@ -14,6 +14,9 @@ packages=find_namespace:
 install_requires =
     inmanta-module-std
 
+[options.packages.find]
+include = inmanta_plugins
+
 [flake8]
 # H101 Include your name with TODOs as in # TODO(yourname). This makes it easier to find out who the author of the comment was.
 # H302 Do not import objects, only modules DEPRICATED

--- a/{{cookiecutter.module_name|slugify}}/setup.cfg
+++ b/{{cookiecutter.module_name|slugify}}/setup.cfg
@@ -15,7 +15,7 @@ install_requires =
     inmanta-module-std
 
 [options.packages.find]
-include = inmanta_plugins
+include = inmanta_plugins*
 
 [flake8]
 # H101 Include your name with TODOs as in # TODO(yourname). This makes it easier to find out who the author of the comment was.


### PR DESCRIPTION
Part of inmanta/inmanta-core#4130

Add config option to limit namespace packages to `inmanta_plugins`