### PR TITLE
Use pip install instead of inmanta module install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                         # follow README instructions exactly
                         python3 -m venv .env && source .env/bin/activate
                         pip install -r requirements.txt -r requirements.dev.txt
-                        inmanta -vvv module install -e .
+                        pip install -e .
                     '''
                 }
             }

--- a/{{cookiecutter.module_name|slugify}}/README.md
+++ b/{{cookiecutter.module_name|slugify}}/README.md
@@ -8,7 +8,7 @@ installed. If you don't, you can replace it with `python3 -m venv .env && source
 ```bash
 mkvirtualenv inmanta-test -p python3
 pip install -r requirements.txt -r requirements.dev.txt
-inmanta -vvv module install -e .
+pip install -e .
 ```
 
 2. Run tests


### PR DESCRIPTION
`inmanta module install` command was removed. Use `pip install` instead.