### PR TITLE
Issue/fix gen non inmanta

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,6 +6,7 @@ This script will make sure that:
 """
 import os
 import subprocess
+import shutil
 
 
 # if the module is not generated for inmanta internal users, remove some unnecessary files
@@ -18,7 +19,7 @@ REMOVE_PATHS = [
 for path in REMOVE_PATHS:
     path = path.strip()
     if path and os.path.exists(path):
-        os.unlink(path) if os.path.isfile(path) else os.rmdir(path)
+        os.unlink(path) if os.path.isfile(path) else shutil.rmtree(path)
 
 # don't abort cookiecutter if git is not installed or not configured properly (i.e. no email address configured)
 subprocess.check_call("git init || true", shell=True)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -5,9 +5,8 @@ This script will make sure that:
 2. The repo is initialized with git
 """
 import os
-import subprocess
 import shutil
-
+import subprocess
 
 # if the module is not generated for inmanta internal users, remove some unnecessary files
 REMOVE_PATHS = [
@@ -19,7 +18,7 @@ REMOVE_PATHS = [
 for path in REMOVE_PATHS:
     path = path.strip()
     if path and os.path.exists(path):
-        os.unlink(path) if os.path.isfile(path) else shutil.rmtree(path)
+        shutil.rmtree(path)
 
 # don't abort cookiecutter if git is not installed or not configured properly (i.e. no email address configured)
 subprocess.check_call("git init || true", shell=True)


### PR DESCRIPTION
MR template cleanup (when author email is not `code@inmanta.com` fails with the following error:
```
$ cookiecutter gh:inmanta/inmanta-module-template
You've downloaded /home/guillaume/.cookiecutters/inmanta-module-template before.
Is it okay to delete and re-download it? [y/n] (y): 
  [1/6] module_name (test_module): 
  [2/6] module_description (): 
  [3/6] author (Inmanta): 
  [4/6] author_email (code@inmanta.com): a
  [5/6] license (ASL 2.0): 
  [6/6] copyright (2025 Inmanta): 
Traceback (most recent call last):
  File "/tmp/tmpfhogco46.py", line 21, in <module>
    os.unlink(path) if os.path.isfile(path) else os.rmdir(path)
                                                 ^^^^^^^^^^^^^^
OSError: [Errno 39] Directory not empty: '.gitlab/merge_request_templates'
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```
This MR fixes this